### PR TITLE
Adding attack and hp tracking

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ function App() {
   const [player, setPlayer] = useState("");
   const [roomCode, setRoomCode] = useState("");
   const [isHost, setIsHost] = useState(false);
+  const [totalPlayers, setTotalPlayers] = useState([]);
   return (
     <div className="App">
       <div>
@@ -22,9 +23,18 @@ function App() {
             setIsHost={setIsHost}
           />
         )}
-        {page === "game" && <GamePage />}
+        {page === "game" && (
+          <GamePage roomCode={roomCode} totalPlayers={totalPlayers} />
+        )}
         {page === "lobby" && (
-          <LobbyPage roomCode={roomCode} isHost={isHost} setPage={setPage} />
+          <LobbyPage
+            roomCode={roomCode}
+            isHost={isHost}
+            setPage={setPage}
+            totalPlayers={totalPlayers}
+            setTotalPlayers={setTotalPlayers}
+            player={player}
+          />
         )}
       </div>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,7 @@ function App() {
             setIsHost={setIsHost}
           />
         )}
-        {page === "game" && (
-          <GamePage roomCode={roomCode} totalPlayers={totalPlayers} />
-        )}
+        {page === "game" && <GamePage roomCode={roomCode} />}
         {page === "lobby" && (
           <LobbyPage
             roomCode={roomCode}

--- a/src/Game/GamePage.js
+++ b/src/Game/GamePage.js
@@ -33,23 +33,27 @@ const GamePage = (props) => {
     fetchHitpoints();
   }, []);
 
+  const updateHitpointValues = (currentState, payload) => {
+    const changeHitpoints = currentState.map((playerData) => {
+      if (payload.new.name === playerData.name) {
+        return {
+          name: payload.new.name,
+          Hitpoints: payload.new.Hitpoints,
+        };
+      } else {
+        return playerData;
+      }
+    });
+    return changeHitpoints;
+  };
+
   useEffect(() => {
     let mySubscription = supabase
       .from("Players")
       .on("UPDATE", (payload) => {
-        setTotalPlayersHp((currentState) => {
-          const changeHitpoints = currentState.map((playerData) => {
-            if (payload.new.name === playerData.name) {
-              return {
-                name: payload.new.name,
-                Hitpoints: payload.new.Hitpoints,
-              };
-            } else {
-              return { name: playerData.name, Hitpoints: playerData.Hitpoints };
-            }
-          });
-          return changeHitpoints;
-        });
+        setTotalPlayersHp((currentState) =>
+          updateHitpointValues(currentState, payload)
+        );
       })
       .subscribe();
     return () => {

--- a/src/Game/GamePage.js
+++ b/src/Game/GamePage.js
@@ -5,7 +5,6 @@ const GamePage = (props) => {
   const { roomCode } = props;
   const [attackTarget, setAttackTarget] = useState("No Target");
   const [totalPlayersHp, setTotalPlayersHp] = useState([]);
-  const stateRef = useRef({ totalPlayersHp });
 
   const handleClick = async () => {
     const targetPlayer = totalPlayersHp.find(
@@ -19,10 +18,6 @@ const GamePage = (props) => {
         .eq("name", attackTarget);
     }
   };
-
-  useEffect(() => {
-    stateRef.current = { totalPlayersHp };
-  }, [totalPlayersHp]);
 
   useEffect(() => {
     const fetchHitpoints = async () => {
@@ -42,17 +37,19 @@ const GamePage = (props) => {
     let mySubscription = supabase
       .from("Players")
       .on("UPDATE", (payload) => {
-        const { totalPlayersHp } = stateRef.current;
-
-        const changeHitpoints = totalPlayersHp.map((playerData) => {
-          if (payload.new.name === playerData.name) {
-            return { name: payload.new.name, Hitpoints: payload.new.Hitpoints };
-          } else {
-            return { name: playerData.name, Hitpoints: playerData.Hitpoints };
-          }
+        setTotalPlayersHp((currentState) => {
+          const changeHitpoints = currentState.map((playerData) => {
+            if (payload.new.name === playerData.name) {
+              return {
+                name: payload.new.name,
+                Hitpoints: payload.new.Hitpoints,
+              };
+            } else {
+              return { name: playerData.name, Hitpoints: playerData.Hitpoints };
+            }
+          });
+          return changeHitpoints;
         });
-
-        setTotalPlayersHp(changeHitpoints);
       })
       .subscribe();
     return () => {

--- a/src/Game/GamePage.js
+++ b/src/Game/GamePage.js
@@ -1,7 +1,67 @@
-const GamePage = () => {
+import { useEffect, useState } from "react";
+import { supabase } from "../supabase_client";
+
+const GamePage = (props) => {
+  const { roomCode, totalPlayers } = props;
+  const [attackTarget, setAttackTarget] = useState();
+  const [totalPlayersHp, setTotalPlayersHp] = useState(["hello"]);
+
+  const handleChange = (e) => {
+    setAttackTarget(e.target.value);
+  };
+
+  const handleClick = () => {};
+
+  useEffect(() => {
+    const fetchHitpoints = async () => {
+      const { data, error } = await supabase
+        .from("Players")
+        .select("name, Hitpoints")
+        .eq("roomID", roomCode);
+      const playerHp = data.map((playerData) => {
+        return { name: playerData.name, Hitpoints: playerData.Hitpoints };
+      });
+      setTotalPlayersHp(playerHp);
+    };
+    fetchHitpoints();
+  }, []);
+
+  useEffect(
+    () => console.log("DID STATE CHANGE? ", totalPlayersHp),
+    [totalPlayersHp]
+  );
+  useEffect(() => console.log("MY COMPONENT MOUNTED "), []);
+  useEffect(() => {
+    let mySubscription = supabase
+      .from("Players:gameStatus=eq.true")
+      .on("UPDATE", (payload) => {
+        console.log(payload);
+        console.log("State variable total players: ", totalPlayersHp);
+        const changeHitpoints = totalPlayersHp.map((playerData) => {
+          if (payload.new.name === playerData.name) {
+            return { name: payload.new.name, Hitpoints: payload.new.Hitpoints };
+          } else {
+            return { name: playerData.name, Hitpoints: playerData.Hitpoints };
+          }
+        });
+        console.log("results from hitpoint map ", changeHitpoints);
+        setTotalPlayersHp(changeHitpoints);
+      })
+      .subscribe();
+  }, []);
   return (
     <div>
       <h1>This is the Game Page</h1>
+      <div>
+        <select name="test" id="test" onChange={handleChange}>
+          {totalPlayersHp.map((element) => (
+            <option value={element.name} key={element.name}>
+              {element.name} HitPoints: {element.Hitpoints}
+            </option>
+          ))}
+        </select>
+        <button onClick={handleClick}>Attack</button>
+      </div>
     </div>
   );
 };

--- a/src/Lobby/LobbyPage.js
+++ b/src/Lobby/LobbyPage.js
@@ -19,7 +19,6 @@ const LobbyPage = (props) => {
     let gameStatusUpdate = supabase
       .from(`Players:name=eq.${player}`)
       .on("UPDATE", (payload) => {
-        console.log("payload in lobby", payload);
         if (
           payload.new.gameStatus === true &&
           payload.new.roomID === roomCode

--- a/src/Lobby/LobbyPage.js
+++ b/src/Lobby/LobbyPage.js
@@ -3,7 +3,8 @@ import { supabase } from "../supabase_client";
 import PlayerList from "./PlayerList";
 
 const LobbyPage = (props) => {
-  const { roomCode, isHost, setPage } = props;
+  const { roomCode, isHost, setPage, totalPlayers, setTotalPlayers, player } =
+    props;
   const [hasGameStarted, setHasGameStarted] = useState(false);
   let pageSelect = "";
 
@@ -16,8 +17,9 @@ const LobbyPage = (props) => {
 
   useEffect(() => {
     let gameStatusUpdate = supabase
-      .from("Players:gameStatus=eq.true")
+      .from(`Players:name=eq.${player}`)
       .on("UPDATE", (payload) => {
+        console.log("payload in lobby", payload);
         if (
           payload.new.gameStatus === true &&
           payload.new.roomID === roomCode
@@ -41,7 +43,12 @@ const LobbyPage = (props) => {
     <div>
       <h1>This is the Lobby page.</h1>
       <h2>Room Code: {roomCode}</h2>
-      <PlayerList roomCode={roomCode} hasGameStarted={hasGameStarted} />
+      <PlayerList
+        roomCode={roomCode}
+        hasGameStarted={hasGameStarted}
+        totalPlayers={totalPlayers}
+        setTotalPlayers={setTotalPlayers}
+      />
       <div>
         {isHost === true && <button onClick={handleClick}>Start Game</button>}
       </div>

--- a/src/Lobby/PlayerList.js
+++ b/src/Lobby/PlayerList.js
@@ -2,8 +2,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "../supabase_client";
 
 const PlayerList = (props) => {
-  const { roomCode, hasGameStarted } = props;
-  const [totalPlayers, setTotalPlayers] = useState([]);
+  const { roomCode, hasGameStarted, totalPlayers, setTotalPlayers } = props;
 
   const fetchPlayerNames = async () => {
     const { data } = await supabase


### PR DESCRIPTION
The Player hit points for each player in the lobby is displayed on the screen. The main player will copy and paste or type in the name of the player that they wish to attack, and the targeted player will lose 20 hit points. The change in hit points will be reflected in a live update on the screen for all players.

![image](https://user-images.githubusercontent.com/55774590/172969121-a412d77c-d90b-4055-83bd-5963d464d64e.png)
