### PR TITLE
preventing unhappy paths from occurring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,9 +21,10 @@ function App() {
             setPage={setPage}
             setRoomCode={setRoomCode}
             setIsHost={setIsHost}
+            roomCode={roomCode}
           />
         )}
-        {page === "game" && <GamePage roomCode={roomCode} />}
+        {page === "game" && <GamePage roomCode={roomCode} player={player} />}
         {page === "lobby" && (
           <LobbyPage
             roomCode={roomCode}

--- a/src/Game/GamePage.js
+++ b/src/Game/GamePage.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { supabase } from "../supabase_client";
 
 const GamePage = (props) => {
-  const { roomCode } = props;
+  const { roomCode, player } = props;
   const [totalPlayersHp, setTotalPlayersHp] = useState([]);
   const [attackTarget, setAttackTarget] = useState("Select a target");
 
@@ -24,7 +24,8 @@ const GamePage = (props) => {
       const { data, error } = await supabase
         .from("Players")
         .select("name, Hitpoints")
-        .eq("roomID", roomCode);
+        .eq("roomID", roomCode)
+        .neq("name", player);
       const playerHp = data.map((playerData) => {
         return { name: playerData.name, Hitpoints: playerData.Hitpoints };
       });
@@ -32,6 +33,10 @@ const GamePage = (props) => {
     };
     fetchHitpoints();
   }, []);
+
+  useEffect(() => {
+    console.log("total player hp state: ", totalPlayersHp);
+  }, [totalPlayersHp]);
 
   const updateHitpointValues = (currentState, payload) => {
     const changeHitpoints = currentState.map((playerData) => {

--- a/src/Home/CreatePlayerButton.js
+++ b/src/Home/CreatePlayerButton.js
@@ -5,15 +5,31 @@ import CreateRoomButton from "./CreateRoomButton";
 
 const CreatePlayerButton = (props) => {
   const [usernameInput, setUsernameInput] = useState();
+  const [usernameTaken, setUsernameTaken] = useState(false);
   const { player, setPlayer, setPage, setRoomCode, setIsHost } = props;
   const onChange = (e) => {
     setUsernameInput(e.target.value);
   };
+
+  const fetchPlayerNames = async () => {
+    const { data } = await supabase.from("Players").select("name");
+    const registeredPlayers = data;
+    return registeredPlayers;
+  };
   const handleClick = async () => {
-    setPlayer(usernameInput);
-    const { error, status } = await supabase
-      .from("Players")
-      .insert([{ name: usernameInput }]);
+    const takenPlayerNames = await fetchPlayerNames();
+    const takenName = takenPlayerNames.find(
+      (playerNames) => playerNames.name === usernameInput
+    );
+    console.log(takenName);
+    if (takenName === undefined) {
+      setPlayer(usernameInput);
+      const { error, status } = await supabase
+        .from("Players")
+        .insert([{ name: usernameInput }]);
+    } else {
+      setUsernameTaken(true);
+    }
   };
   return (
     <div>
@@ -23,6 +39,11 @@ const CreatePlayerButton = (props) => {
         <button onClick={handleClick} disabled={player !== ""}>
           Set Username
         </button>
+        <div>
+          {usernameTaken === true && player === "" && (
+            <h3>That username is taken, Please enter another name.</h3>
+          )}
+        </div>
       </div>
 
       <CreateRoomButton

--- a/src/Home/CreatePlayerButton.js
+++ b/src/Home/CreatePlayerButton.js
@@ -5,7 +5,7 @@ import CreateRoomButton from "./CreateRoomButton";
 
 const CreatePlayerButton = (props) => {
   const [usernameInput, setUsernameInput] = useState();
-  const [usernameTaken, setUsernameTaken] = useState(false);
+  const [usernameTaken, setUsernameTaken] = useState();
   const { player, setPlayer, setPage, setRoomCode, setIsHost } = props;
 
   const onChange = (e) => {
@@ -13,14 +13,18 @@ const CreatePlayerButton = (props) => {
   };
 
   const handleClick = async () => {
+    let fetchUsername = "";
+    let isNameTaken = false;
     const { data, error, status } = await supabase
       .from("Players")
       .insert([{ name: usernameInput }]);
     if (error === null) {
-      setPlayer(usernameInput);
+      fetchUsername = usernameInput;
     } else {
-      setUsernameTaken(true);
+      isNameTaken = true;
     }
+    setPlayer(fetchUsername);
+    setUsernameTaken(isNameTaken);
   };
   return (
     <div>
@@ -30,11 +34,10 @@ const CreatePlayerButton = (props) => {
         <button onClick={handleClick} disabled={player !== ""}>
           Set Username
         </button>
-        <div>
-          {usernameTaken === true && player === "" && (
-            <h3>That username is taken, Please enter another name.</h3>
-          )}
-        </div>
+
+        {usernameTaken === true && player === "" && (
+          <h3>That username is taken, Please enter another name.</h3>
+        )}
       </div>
 
       <CreateRoomButton

--- a/src/Home/CreatePlayerButton.js
+++ b/src/Home/CreatePlayerButton.js
@@ -7,26 +7,17 @@ const CreatePlayerButton = (props) => {
   const [usernameInput, setUsernameInput] = useState();
   const [usernameTaken, setUsernameTaken] = useState(false);
   const { player, setPlayer, setPage, setRoomCode, setIsHost } = props;
+
   const onChange = (e) => {
     setUsernameInput(e.target.value);
   };
 
-  const fetchPlayerNames = async () => {
-    const { data } = await supabase.from("Players").select("name");
-    const registeredPlayers = data;
-    return registeredPlayers;
-  };
   const handleClick = async () => {
-    const takenPlayerNames = await fetchPlayerNames();
-    const takenName = takenPlayerNames.find(
-      (playerNames) => playerNames.name === usernameInput
-    );
-    console.log(takenName);
-    if (takenName === undefined) {
+    const { data, error, status } = await supabase
+      .from("Players")
+      .insert([{ name: usernameInput }]);
+    if (error === null) {
       setPlayer(usernameInput);
-      const { error, status } = await supabase
-        .from("Players")
-        .insert([{ name: usernameInput }]);
     } else {
       setUsernameTaken(true);
     }

--- a/src/Home/CreateRoomButton.js
+++ b/src/Home/CreateRoomButton.js
@@ -1,18 +1,42 @@
+import { useEffect } from "react";
 import { supabase } from "../supabase_client";
 import { generateRoomCode } from "../utils";
 
 const CreateRoomButton = (props) => {
-  const { player, setPage, setRoomCode, setIsHost } = props;
+  const { player, setPage, setRoomCode, setIsHost, roomCode } = props;
+  let pageSelect = "home";
+  let hostSelect = false;
+  let roomSelect = null;
+
+  const fetchRoomCodes = async () => {
+    const { data } = await supabase.from("Players").select("roomID");
+    const registeredRooms = data;
+    return registeredRooms;
+  };
+
   const handleClick = async () => {
     const roomID = generateRoomCode();
-    setRoomCode(roomID);
-    const { data, error } = await supabase
-      .from("Players")
-      .update({ roomID: roomID })
-      .match({ name: player });
-    setIsHost(true);
-    setPage("lobby");
+    const registeredRooms = await fetchRoomCodes();
+    const existingRoomCode = registeredRooms.find(
+      (rooms) => rooms.roomID === roomID
+    );
+
+    if (existingRoomCode === undefined) {
+      const { data, error } = await supabase
+        .from("Players")
+        .update({ roomID: roomID })
+        .match({ name: player });
+      hostSelect = true;
+      roomSelect = roomID;
+      pageSelect = "lobby";
+    } else {
+      handleClick();
+    }
+    setIsHost(hostSelect);
+    setPage(pageSelect);
+    setRoomCode(roomSelect);
   };
+
   return (
     <div>
       <button onClick={handleClick}>Create Room</button>

--- a/src/Home/CreateRoomButton.js
+++ b/src/Home/CreateRoomButton.js
@@ -4,7 +4,7 @@ import { generateRoomCode } from "../utils";
 
 const CreateRoomButton = (props) => {
   const { player, setPage, setRoomCode, setIsHost, roomCode } = props;
-  const [isRoomTaken, setIsRoomTaken] = useState(false);
+  const [isRoomTaken, setIsRoomTaken] = useState();
 
   const validRoomCode = async () => {
     const roomID = generateRoomCode();
@@ -20,13 +20,14 @@ const CreateRoomButton = (props) => {
     const checkRoomCode = await validRoomCode();
     let pageSelect = "home";
     let hostSelect = false;
+    let roomAlreadyExists = false;
     if (checkRoomCode === null) {
       hostSelect = true;
       pageSelect = "lobby";
     } else {
-      setIsRoomTaken(true);
+      roomAlreadyExists = true;
     }
-
+    setIsRoomTaken(roomAlreadyExists);
     setIsHost(hostSelect);
     setPage(pageSelect);
   };
@@ -34,7 +35,7 @@ const CreateRoomButton = (props) => {
   return (
     <div>
       <button onClick={handleClick}>Create Room</button>
-      {isRoomTaken === true && <h3>Room is in use, please try again</h3>}
+      {isRoomTaken === true && <h3>Room creation , please try again</h3>}
     </div>
   );
 };

--- a/src/Home/JoinRoomButton.js
+++ b/src/Home/JoinRoomButton.js
@@ -4,7 +4,7 @@ import { supabase } from "../supabase_client";
 const JoinRoomButton = (props) => {
   const { player, setPage, setRoomCode } = props;
   const [userRoomInput, setUserRoomInput] = useState();
-  const [roomExists, setRoomExists] = useState(true);
+  const [roomExists, setRoomExists] = useState();
 
   const onChange = (e) => {
     setUserRoomInput(e.target.value);
@@ -12,6 +12,7 @@ const JoinRoomButton = (props) => {
 
   const handleClick = async () => {
     let pageSelect = "";
+    let isRoomValid = true;
     const { data, error } = await supabase
       .from("Players")
       .select("roomID")
@@ -23,9 +24,10 @@ const JoinRoomButton = (props) => {
         .match({ name: player });
       pageSelect = "lobby";
     } else {
-      setRoomExists(false);
+      isRoomValid = false;
       pageSelect = "home";
     }
+    setRoomExists(isRoomValid);
     setPage(pageSelect);
     setRoomCode(userRoomInput);
   };

--- a/src/Home/JoinRoomButton.js
+++ b/src/Home/JoinRoomButton.js
@@ -39,7 +39,7 @@ const JoinRoomButton = (props) => {
         ></input>
         <button onClick={handleClick}>Join Room</button>
       </div>
-      <div>{roomExists === false && <h2>That Room Does Not Exist</h2>}</div>
+      {roomExists === false && <h2>That Room Does Not Exist</h2>}
     </div>
   );
 };


### PR DESCRIPTION
Adding in constraints to prevent users from having the same username, or getting the same room code as an existing room in the system. Additionally, removed the bug to view players own name under attack targets.
![image](https://user-images.githubusercontent.com/55774590/173259272-3a0136c1-a651-4369-a1c3-74a3fb8284bf.png)
![image](https://user-images.githubusercontent.com/55774590/173259291-0e24ccaa-2635-498d-a2ad-aa8ab940cc4f.png)
